### PR TITLE
Add engine for schema

### DIFF
--- a/app/controllers/vandal_ui/schemas_controller.rb
+++ b/app/controllers/vandal_ui/schemas_controller.rb
@@ -1,0 +1,6 @@
+class VandalUi::SchemasController < ActionController::API
+  def show
+    Rails.application.eager_load!
+    render json: Graphiti::Schema.generate
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,3 @@
+VandalUi::Engine.routes.draw do
+  get '/schema', to: 'vandal_ui/schemas#show'
+end

--- a/lib/vandal_ui.rb
+++ b/lib/vandal_ui.rb
@@ -1,5 +1,6 @@
 require "vandal_ui/version"
 require "vandal_ui/railtie" if defined?(Rails)
+require "vandal_ui/engine" if defined?(Rails)
 
 module VandalUi
 end

--- a/lib/vandal_ui/engine.rb
+++ b/lib/vandal_ui/engine.rb
@@ -1,0 +1,4 @@
+module VandalUi
+  class Engine < ::Rails::Engine
+  end
+end

--- a/lib/vandal_ui/tasks.rb
+++ b/lib/vandal_ui/tasks.rb
@@ -2,7 +2,9 @@ namespace :vandal do
   task :install do
     cfg = YAML.load_file("#{Rails.root}/.graphiticfg.yml")
     namespace = cfg['namespace']
-    schema_path = "#{namespace}/schema.json"
+
+    vandal_path = VandalUi::Engine.routes.find_script_name({})
+    schema_path = "#{vandal_path}/schema.json"
 
     source = File.join(File.dirname(__FILE__), 'static')
     destination = "#{Rails.root}/public/#{namespace}"


### PR DESCRIPTION
Sometimes, the schema needs to be generated dynamically. An example is
remote resources with paths dependent on environment variables.

So, this adds an engine/route/controller to do so, and changes the
install script to point to that endpoint. This means those who omit
vandal still get a schema hosted in `public` with
backwards-compatibility checks as normal, but vandal users will
reference a dynamically-generated schema.