### PR TITLE
Display the clear error message when Graphiti config is missing 

### DIFF
--- a/lib/vandal_ui/tasks.rb
+++ b/lib/vandal_ui/tasks.rb
@@ -1,6 +1,12 @@
 namespace :vandal do
   task install: [:environment] do
-    cfg = YAML.load_file("#{Rails.root}/.graphiticfg.yml")
+    graphiti_config_path = "#{Rails.root}/.graphiticfg.yml"
+    unless File.exist?(graphiti_config_path)
+      raise "Valid graphiti config file is required in the Rails root directory.\n" \
+            "More information: https://www.graphiti.dev/guides/getting-started/installation#graphiticfg"
+    end
+
+    cfg = YAML.load_file(graphiti_config_path)
     namespace = cfg['namespace']
 
     vandal_path = VandalUi::Engine.routes.find_script_name({})


### PR DESCRIPTION
This PR resolves #3. I coded it before noticing the existing issue, so I just made it in the way I found most convenient for the user, i.e. instead of adjusting documentation it just assumes lack of namespace if unconfigured.

Feel free to reject it if you find the other solution more appropriate :-)