### PR TITLE
Load all .rb files in /app/resources, but not directories

### DIFF
--- a/app/controllers/vandal_ui/schemas_controller.rb
+++ b/app/controllers/vandal_ui/schemas_controller.rb
@@ -1,7 +1,7 @@
 class VandalUi::SchemasController < ActionController::API
   def show
     Rails.application.eager_load!
-    Dir.glob("#{Rails.root}/app/resources/*").each do |f|
+    Dir.glob("#{Rails.root}/app/resources/**/*.rb").each do |f|
       require f
     end
     render json: Graphiti::Schema.generate


### PR DESCRIPTION
This fixes an issue when there are namespaces in use with files such as `/app/resources/namespace/model_resource.rb`. Previously, there was an error because it tried to load the directory as a file.