### PR TITLE
Fix NameError: uninitialized constant VandalUi

### DIFF
--- a/app/controllers/vandal_ui/schemas_controller.rb
+++ b/app/controllers/vandal_ui/schemas_controller.rb
@@ -1,4 +1,4 @@
-class VandalUi::SchemasController < ActionController::API
+class VandalUI::SchemasController < ActionController::API
   def show
     Rails.application.eager_load!
     Dir.glob("#{Rails.root}/app/resources/**/*.rb").each do |f|


### PR DESCRIPTION
Without this adjustment I get an error trying to load the last 2 released versions in a Rails 5.2 app. Perhaps there's somewhere else that needs to be adjusted instead?